### PR TITLE
Fixing flaky test

### DIFF
--- a/pyGPGO/surrogates/tStudentProcess.py
+++ b/pyGPGO/surrogates/tStudentProcess.py
@@ -144,7 +144,7 @@ class tStudentProcess:
             k_param[k] = x
         self.covfunc = self.covfunc.__class__(**k_param, bounds=self.covfunc.bounds)
 
-    def fit(self, X, y):
+    def fit(self, X, y, n_trials=5):
         """
         Fits a t-Student Process regressor
 
@@ -161,7 +161,7 @@ class tStudentProcess:
         self.n1 = X.shape[0]
 
         if self.optimize:
-            self.optHyp(param_key=self.covfunc.parameters, param_bounds=self.covfunc.bounds)
+            self.optHyp(param_key=self.covfunc.parameters, param_bounds=self.covfunc.bounds, n_trials=n_trials)
 
         self.K11 = self.covfunc.K(self.X, self.X)
         self.beta1 = np.dot(np.dot(self.y.T, inv(self.K11)), self.y)

--- a/tests/test_surrogates.py
+++ b/tests/test_surrogates.py
@@ -21,7 +21,7 @@ def test_GP_opt_nograd():
 
     sexp = squaredExponential()
     gp = GaussianProcess(sexp, optimize=True, usegrads=False)
-    gp.fit(X, y)
+    gp.fit(X, y, 20)
 
     params = gp.getcovparams()
 


### PR DESCRIPTION
This is a fix for the issue #31. The test was failing when the seed was not set. We observed that increase number of trials to 20 decreases the flakiness to ~0%. To enable this change, we added a parameter to the `fit` function in `pyGPGO/surrogates/tStudentProcess.py`. Please let us know if this change seems reasonable.

We will be happy to incorporate any other suggestions. Thanks!

If you think this is useful, we can also look into other tests that were failing.